### PR TITLE
Fixes two tests that fail because of automatic Salesforce translations when creating the scratch org

### DIFF
--- a/force-app/main/default/classes/MA_ReportServiceTest.cls
+++ b/force-app/main/default/classes/MA_ReportServiceTest.cls
@@ -63,8 +63,8 @@ private class MA_ReportServiceTest {
         setup();
 
         Map<String, String> expectedColumns = new Map<String, String>{
-            'ACCOUNT_ID' => 'Account ID',
-            'PARENT_ID'  => 'Parent Account ID'
+            'ACCOUNT_ID' => Schema.Account.Id.getDescribe().getLabel(),
+            'PARENT_ID'  => Schema.Account.ParentId.getDescribe().getLabel()
         };
 
         Report testReport = [

--- a/force-app/main/default/classes/MA_ReportSourceBatchableTest.cls
+++ b/force-app/main/default/classes/MA_ReportSourceBatchableTest.cls
@@ -249,9 +249,15 @@ private class MA_ReportSourceBatchableTest {
             // then we're getting a synchronous exception caught rather than
             // the job's finish method logging the error asynchronously
             noDataFoundExceptionThrown = true;
+
+        } catch (Exception e) {
+
+            // catch other types of exceptions
+            System.assert( false, 'failed for the wrong reason' );
+
         }
 
-        System.assert(noDataFoundExceptionThrown);
+        System.assert( noDataFoundExceptionThrown, 'should have failed with a \'NoDataFoundException\'.' );
 
     }
 

--- a/force-app/main/default/classes/MA_ReportSourceBatchableTest.cls
+++ b/force-app/main/default/classes/MA_ReportSourceBatchableTest.cls
@@ -198,6 +198,8 @@ private class MA_ReportSourceBatchableTest {
     @IsTest( SeeAllData = true )
     static void test_batchable_fail_no_report() {
 
+        Boolean noDataFoundExceptionThrown = false;
+
         Mass_Action_Configuration__c config = buildTestConfiguration();
         config.Source_Report_ID__c = null;
         config.Target_Type__c = 'Workflow';
@@ -246,9 +248,10 @@ private class MA_ReportSourceBatchableTest {
             // because the batchable throws the error in the start method
             // then we're getting a synchronous exception caught rather than
             // the job's finish method logging the error asynchronously
-            System.assert( ex.getMessage().containsIgnoreCase( 'The data you’re trying to access is unavailable' ), 'failed for wrong reason' );
-
+            noDataFoundExceptionThrown = true;
         }
+
+        System.assert(noDataFoundExceptionThrown);
 
     }
 


### PR DESCRIPTION
When creating a scratch org Salesforce seems to determine the language/locale automatically. When I created the scratch org I got my org in Brazilian Portuguese instead of US English.

This commit fixes the field label issues by getting them dynamically with .getLabel() and error message issue as well. Both when creating a scratch org in a language other than US English.

Since the `NoDataFoundException` exception is a built-in one, I don't think it is necessary to assert the content of the message. It seems enough to assert that the exception was thrown, and the test already specifies its type instead of handling the generic `Exception` type.