### PR TITLE
Fix CircleCI Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
                 name: Run Apex Tests
                 command: |
                     mkdir -p ./tests/apex
-                    node_modules/sfdx-cli/bin/run force:apex:test:run --targetusername ciorg --codecoverage --resultformat human --outputdir ./test-results/apex --wait 20
+                    node_modules/sfdx-cli/bin/run force:apex:test:run --targetusername ciorg --codecoverage --resultformat human --suitenames Mass_Action_Scheduler_Test_Suite --outputdir ./test-results/apex --wait 20
             - persist_to_workspace:
                 # The Apex test will store the test results in the `test-results` folder (which is a sub-folder of 'project')
                 # The test data will be uploaded to Codecov.io in another step.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,9 +140,11 @@ workflows:
                 requires:
                     - setup_tooling
             - deploy_source:
+                context: douglascayers-org
                 requires:
                     - setup_dx_orgs
             - run_apex_tests:
+                context: douglascayers-org
                 requires:
                     - deploy_source
             - upload_code_coverage:
@@ -150,6 +152,7 @@ workflows:
                 requires:
                     - run_apex_tests
             - cleanup_dx_orgs:
+                context: douglascayers-org
                 requires:
                     - setup_dx_orgs
                     - deploy_source

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,7 +1,7 @@
 {
     "orgName" : "Mass Action Scheduler",
     "edition" : "Enterprise",
-    "hasSampleData" : true,
+    "hasSampleData" : false,
     "features" : [],
     "settings" : {
         "orgPreferenceSettings" : {

--- a/force-app/main/default/classes/MA_EditConfigRestController.cls
+++ b/force-app/main/default/classes/MA_EditConfigRestController.cls
@@ -448,7 +448,7 @@ global with sharing class MA_EditConfigRestController {
         for ( AggregateResult result : [
             SELECT SObjectType
             FROM ListView
-            WHERE IsSoqlCompatible = true
+            WHERE IsSoqlCompatible = true AND SObjectType != null
             GROUP BY SObjectType
             ORDER BY SObjectType ASC
             LIMIT 2000

--- a/force-app/main/default/classes/MA_EditConfigRestControllerTest.cls
+++ b/force-app/main/default/classes/MA_EditConfigRestControllerTest.cls
@@ -425,7 +425,7 @@ private class MA_EditConfigRestControllerTest {
         for ( AggregateResult result : [
             SELECT SObjectType
             FROM ListView
-            WHERE IsSoqlCompatible = true
+            WHERE IsSoqlCompatible = true AND SObjectType != null
             GROUP BY SObjectType
             ORDER BY SObjectType ASC
             LIMIT 2000

--- a/force-app/main/default/testSuites/Mass_Action_Scheduler_Test_Suite.testSuite-meta.xml
+++ b/force-app/main/default/testSuites/Mass_Action_Scheduler_Test_Suite.testSuite-meta.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTestSuite xmlns="http://soap.sforce.com/2006/04/metadata">
+    <testClassName>LC_URLControllerTest</testClassName>
+    <testClassName>LC_VisualforceDomainControllerTest</testClassName>
+    <testClassName>MA_BatchApexErrorEventInvocableTest</testClassName>
+    <testClassName>MA_BatchApexStatusEventTriggerTest</testClassName>
+    <testClassName>MA_EditConfigCmpControllerTest</testClassName>
+    <testClassName>MA_EditConfigRestControllerTest</testClassName>
+    <testClassName>MA_ExceptionsTest</testClassName>
+    <testClassName>MA_InstallHandlerTest</testClassName>
+    <testClassName>MA_IterableSourceBatchableTest</testClassName>
+    <testClassName>MA_JobChangeEventTriggerHandlerTest</testClassName>
+    <testClassName>MA_ListViewDescribeResultTest</testClassName>
+    <testClassName>MA_ListViewSourceBatchableTest</testClassName>
+    <testClassName>MA_MapUtilsTest</testClassName>
+    <testClassName>MA_MassActionBatchUtilsTest</testClassName>
+    <testClassName>MA_MassActionConfigTriggerHandlerTest</testClassName>
+    <testClassName>MA_MassActionLogTriggerHandlerTest</testClassName>
+    <testClassName>MA_MassActionSchedulableTest</testClassName>
+    <testClassName>MA_MassActionScheduleUtilsTest</testClassName>
+    <testClassName>MA_MetadataDeployCallbackTest</testClassName>
+    <testClassName>MA_ReportServiceTest</testClassName>
+    <testClassName>MA_ReportSourceBatchableTest</testClassName>
+    <testClassName>MA_RunConfigCmpControllerTest</testClassName>
+    <testClassName>MA_RunConfigInvocableTest</testClassName>
+    <testClassName>MA_SetConfigUniqueNameBatchableTest</testClassName>
+    <testClassName>MA_SetupAuthWizardPageControllerTest</testClassName>
+    <testClassName>MA_SoqlQueryExecuteResultTest</testClassName>
+    <testClassName>MA_SoqlSourceBatchableTest</testClassName>
+    <testClassName>MA_SoqlSourceIterableTest</testClassName>
+    <testClassName>MA_StringUtilsTest</testClassName>
+    <testClassName>MA_UpgradeMassActionLogsBatchableTest</testClassName>
+    <testClassName>MA_UpgradePageLayoutsServiceTest</testClassName>
+    <testClassName>MA_XMLUtilsTest</testClassName>
+</ApexTestSuite>

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -245,6 +245,10 @@
     <members>Mass_Action_Log__c</members>
   </types>
   <types>
+    <name>ApexTestSuite</name>
+    <members>Mass_Action_Scheduler_Test_Suite</members>
+  </types>
+  <types>
     <name>ApexTrigger</name>
     <members>MA_BatchApexStatusEventTrigger</members>
     <members>MA_JobChangeEventTrigger</members>


### PR DESCRIPTION
### What does this pull request do?

* Creates Enterprise Edition scratch org without sample data so that extraneous Apex classes and Visualforce pages don't exist in the org, skewing test results and code coverage.
* Filter ListViews that don't belong to SObjects